### PR TITLE
Add markdown_to_html filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,15 @@
     <div>
         {% markdown '../or/embed/external/file.md' %}{% endmarkdown %}
     </div>
+    <div>
+        {% apply markdown_to_html %}
+            # Title
+        {% endapply %}
+    </div>
+    <div>
+        {% set content = '# Title' %}
+        {{ content|markdown_to_html }}
+    </div>
 </div>
 ```
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -4658,19 +4658,10 @@
                 "node": ">=0.10.0"
             }
         },
-        "node_modules/snapdragon/node_modules/source-map": {
-            "version": "0.5.7",
-            "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-            "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-            "dev": true,
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
         "node_modules/source-map": {
-            "version": "0.7.3",
-            "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
-            "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==",
+            "version": "0.7.4",
+            "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.4.tgz",
+            "integrity": "sha512-l3BikUxvPOcn5E74dZiq5BGsTb5yEwhaTSzccU6t4sDOH8NWJCstKO5QT2CvtFoK6F0saL7p9xHAqHOlCPJygA==",
             "dev": true,
             "engines": {
                 "node": ">= 8"
@@ -7466,7 +7457,7 @@
             "requires": {
                 "ansi-colors": "^4.1.1",
                 "plugin-error": "^1.0.1",
-                "source-map": "^0.7.3",
+                "source-map": "0.7.4",
                 "through2": "^3.0.1",
                 "vinyl": "^2.2.0",
                 "vinyl-fs": "^3.0.3"
@@ -9245,7 +9236,7 @@
                 "define-property": "^0.2.5",
                 "extend-shallow": "^2.0.1",
                 "map-cache": "^0.2.2",
-                "source-map": "^0.5.6",
+                "source-map": "0.7.4",
                 "source-map-resolve": "^0.5.0",
                 "use": "^3.1.0"
             },
@@ -9324,12 +9315,6 @@
                     "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
                     "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
                     "dev": true
-                },
-                "source-map": {
-                    "version": "0.5.7",
-                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-                    "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-                    "dev": true
                 }
             }
         },
@@ -9376,9 +9361,9 @@
             }
         },
         "source-map": {
-            "version": "0.7.3",
-            "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
-            "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==",
+            "version": "0.7.4",
+            "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.4.tgz",
+            "integrity": "sha512-l3BikUxvPOcn5E74dZiq5BGsTb5yEwhaTSzccU6t4sDOH8NWJCstKO5QT2CvtFoK6F0saL7p9xHAqHOlCPJygA==",
             "dev": true
         },
         "source-map-resolve": {

--- a/package.json
+++ b/package.json
@@ -32,6 +32,9 @@
         "ts-node": "^10",
         "typescript": "^4"
     },
+    "overrides":{
+        "source-map": "0.7.4"
+    },     
     "keywords": [
         "markdown",
         "md",

--- a/source/ts/Extension.ts
+++ b/source/ts/Extension.ts
@@ -90,6 +90,19 @@ export function extend(twig: Twig, options: any = {}): void {
         open: false
     };
 
+    /**
+     * The `markdown_to_html` filter to match Twig's filter syntax.
+     *
+     * @param content The content that is passed to the filter.
+     * @returns The HTML that is rendered markdown content.
+     * @see https://twig.symfony.com/doc/3.x/filters/markdown_to_html.html
+     */
+    function markdownToHtmlFilter(content: string): string {
+        content = unindent(content);
+        return marked(content, options);
+    }
+
     twig.exports.extendTag(markdownToken);
     twig.exports.extendTag(endmarkdownToken);
+    twig.exports.extendFilter('markdown_to_html', markdownToHtmlFilter);
 }

--- a/source/ts/Test/ExtensionTestCase.ts
+++ b/source/ts/Test/ExtensionTestCase.ts
@@ -26,6 +26,19 @@ suite('twig markdown', function() {
     //     var template = twig.twig({ data: "{% markdown './test/markdown.md' %}" });
     //     template.render().should.equal('<h1 id="foo">foo</h1>\n<p>bar</p>\n');
     // });
+
+    test('compile markdown in a filter with apply', function() {
+        const template = twig.twig({ data: "{% apply markdown_to_html %}# Foo{% endapply %}" });
+        template.render().should.equal('<h1 id="foo">Foo</h1>\n');
+    });
+
+    test('compile markdown in a filter with a pipe', function() {
+        const template = twig.twig({ data: "{{ content|markdown_to_html }}" });
+        const variables = {
+            'content': '# Foo'
+        }
+        template.render(variables).should.equal('<h1 id="foo">Foo</h1>\n');
+    });
 });
 
 suite('unindent', function() {


### PR DESCRIPTION
This adds the `markdown_to_html` filter...

Was getting some errors on `npm run build`, so forcing an update to `source-map` with an override fixed it.

Fixes #4
